### PR TITLE
[mod]-[fix_error_no.1]

### DIFF
--- a/2048.c
+++ b/2048.c
@@ -10,9 +10,9 @@
 
 // Keyboard ASCII
 #define Up 72
-#define Right 77
+#define right 77
 #define Down 80
-#define Left 75
+#define left 75
 
 // Global vals
 bool anim;
@@ -366,9 +366,9 @@ unsigned short getAction(){
   if (ch == 0xE0){
    switch(getch()){
     case Up: return 0; break;		// Up입력
-    case Right: return 1; break;	// Right입력
+    case right: return 1; break;	// Right입력
     case Down: return 2; break;		// Down 입력
-    case Left: return 3; break;		// Left 입력
+    case left: return 3; break;		// Left 입력
    }
   } 
   /* a키를 입력 받을때 */


### PR DESCRIPTION
Error Solution

소스코드 시작부분에 define으로 값을 설정해놓은
getAction에 사용되는 Left, Right가

init에 사용되는

COORD new_size = {info.srWindow.Right-info.srWindow.Left+1,info.srWindow.Bottom-info.srWindow.Top+1};
에 저장되는 내장함수의 'Left', 'Right'와 겹쳐서 에러가 발생

해결 방법
상단에 define과 getAction의 'Left', 'Right'를 -> 'left', 'right'로 변경